### PR TITLE
Set gradle dependency to compile instead of implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-  implementation 'commons-codec:commons-codec:1.8'
+  compile 'commons-codec:commons-codec:1.8'
   testCompile 'junit:junit:4.12'
 }
 


### PR DESCRIPTION
For some reason using 'implementation' or 'api' throws
`package org.apache.commons.codec.binary does not exist`

Changing this to 'compile' fixes this for now.