### PR TITLE
Add salt() method for custom salts

### DIFF
--- a/src/main/java/com/amdelamar/jhash/algorithms/SCrypt.java
+++ b/src/main/java/com/amdelamar/jhash/algorithms/SCrypt.java
@@ -299,26 +299,30 @@ public class SCrypt {
      * @param cost       Overall CPU/MEM cost parameter. 2^15 for testing, but 2^20 recommended.
      * @return The hashed password.
      * @throws IllegalStateException If JVM doesn't support necessary functions.
+     * @deprecated use {@link #create(String, byte[], int)} instead.
      */
+    @Deprecated
     public static String create(String password, int saltLength, int cost) throws IllegalStateException {
-        return create(password, saltLength, cost, BLOCKSIZE, PARALLEL);
+        // Generate a salt of the specified length
+        final byte[] salt = HashUtils.randomSalt(saltLength);
+        return create(password, salt, cost, BLOCKSIZE, PARALLEL);
     }
 
     /**
-     * Hash the supplied plaintext password and generate output in the format described
+     * Creates a Hash from the given password using the specified algorithm.
      *
      * @param password   Password.
-     * @param saltLength The salt byte length.
+     * @param salt       The salt bytes
      * @param cost       Overall CPU/MEM cost parameter. 2^15 for testing, but 2^20 recommended.
-     * @param blockSize  Block size for each mixing loop (memory usage)
-     * @param parallel   Parallelization to control the number of independent mixing loops.
      * @return The hashed password.
      * @throws IllegalStateException If JVM doesn't support necessary functions.
      */
-    protected static String create(String password, int saltLength, int cost, int blockSize, int parallel) throws IllegalStateException {
-        try {
-            final byte[] salt = HashUtils.randomSalt(saltLength);
+    public static String create(String password, byte[] salt, int cost) throws IllegalStateException {
+        return create(password, salt, cost, BLOCKSIZE, PARALLEL);
+    }
 
+    private static String create(String password, byte[] salt, int cost, int blockSize, int parallel) throws IllegalStateException {
+        try {
             final byte[] derived = scrypt(password.getBytes("UTF-8"), salt, cost, blockSize, parallel, 32);
 
             final String params = Long.toString(log2(cost) << 16L | blockSize << 8 | parallel, 16);

--- a/src/test/java/com/amdelamar/jhash/algorithms/BCryptTests.java
+++ b/src/test/java/com/amdelamar/jhash/algorithms/BCryptTests.java
@@ -59,6 +59,20 @@ public class BCryptTests {
     }
 
     @Test
+    public void customSaltTests() throws InvalidHashException {
+        char[] password = "Hello&77World!".toCharArray();
+        // bcrypt + custom salt
+        String hash = Hash.password(password)
+                .algorithm(Type.BCRYPT)
+                .saltLength(1) // should be overridden
+                .salt("pretzel".getBytes())
+                .saltLength(10) // should be ignored
+                .create();
+        assertTrue(Hash.password(password)
+                .verify(hash));
+    }
+
+    @Test
     public void defaultFactorTests() throws InvalidHashException {
 
         int parameter = 10;

--- a/src/test/java/com/amdelamar/jhash/algorithms/PBKDF2Tests.java
+++ b/src/test/java/com/amdelamar/jhash/algorithms/PBKDF2Tests.java
@@ -103,6 +103,20 @@ public class PBKDF2Tests {
     }
 
     @Test
+    public void customSaltTests() throws InvalidHashException {
+        char[] password = "Hello&77World!".toCharArray();
+        // sha512 + custom salt
+        String hash = Hash.password(password)
+                .algorithm(Type.PBKDF2_SHA512)
+                .saltLength(1) // should be overridden
+                .salt("pretzel".getBytes())
+                .saltLength(10) // should be ignored
+                .create();
+        assertTrue(Hash.password(password)
+                .verify(hash));
+    }
+
+    @Test
     public void lowFactorTests() throws InvalidHashException {
 
         int factor = 500;

--- a/src/test/java/com/amdelamar/jhash/algorithms/SCryptTests.java
+++ b/src/test/java/com/amdelamar/jhash/algorithms/SCryptTests.java
@@ -58,6 +58,20 @@ public class SCryptTests {
     }
 
     @Test
+    public void customSaltTests() throws InvalidHashException {
+        char[] password = "Hello&77World!".toCharArray();
+        // scrypt + custom salt
+        String hash = Hash.password(password)
+                .algorithm(Type.SCRYPT)
+                .saltLength(1) // should be overridden
+                .salt("pretzel".getBytes())
+                .saltLength(10) // should be ignored
+                .create();
+        assertTrue(Hash.password(password)
+                .verify(hash));
+    }
+
+    @Test
     public void lowFactorTests() throws InvalidHashException {
 
         int parameter = 16384;


### PR DESCRIPTION
Allows users to specify their own salt values
when generating the password hash. Instead of
relying on the automatic salting Jhash does.

Note: Calling salt() will override saltLength()
And calling saltLength() after setting a salt()
will be ignored.

Fixes #11